### PR TITLE
Add type hints and docstrings to root utilities

### DIFF
--- a/download_dataset.py
+++ b/download_dataset.py
@@ -1,45 +1,76 @@
+"""Utilities for downloading datasets from the UCI repository.
+
+This module provides small helper functions that download and unzip
+public datasets used throughout the project. The functions are intentionally
+lightweight so they can be imported and reused in tests or scripts without
+side effects.
+"""
+
+from __future__ import annotations
+
 import os
-import numpy
-import pandas as pd
 from urllib import request
-import shutil
 import zipfile
 
-DATA_DIR = 'data'
+from typing import Dict
 
 
-NAME_URL_DICT_UCI = {
-    'adult': 'https://archive.ics.uci.edu/static/public/2/adult.zip',
-    'default': 'https://archive.ics.uci.edu/static/public/350/default+of+credit+card+clients.zip',
-    'magic': 'https://archive.ics.uci.edu/static/public/159/magic+gamma+telescope.zip',
-    'shoppers': 'https://archive.ics.uci.edu/static/public/468/online+shoppers+purchasing+intention+dataset.zip',
-    'beijing': 'https://archive.ics.uci.edu/static/public/381/beijing+pm2+5+data.zip',
-    'news': 'https://archive.ics.uci.edu/static/public/332/online+news+popularity.zip'
+# Base directory where datasets will be stored
+DATA_DIR = "data"
+
+
+# Mapping from dataset name to the corresponding UCI download URL
+NAME_URL_DICT_UCI: Dict[str, str] = {
+    "adult": "https://archive.ics.uci.edu/static/public/2/adult.zip",
+    "default": "https://archive.ics.uci.edu/static/public/350/default+of+credit+card+clients.zip",
+    "magic": "https://archive.ics.uci.edu/static/public/159/magic+gamma+telescope.zip",
+    "shoppers": "https://archive.ics.uci.edu/static/public/468/online+shoppers+purchasing+intention+dataset.zip",
+    "beijing": "https://archive.ics.uci.edu/static/public/381/beijing+pm2+5+data.zip",
+    "news": "https://archive.ics.uci.edu/static/public/332/online+news+popularity.zip",
 }
 
-def unzip_file(zip_filepath, dest_path):
-    with zipfile.ZipFile(zip_filepath, 'r') as zip_ref:
+
+def unzip_file(zip_filepath: str, dest_path: str) -> None:
+    """Extract a ZIP archive to a destination directory.
+
+    Args:
+        zip_filepath: Path to the ZIP file to be extracted.
+        dest_path: Directory where the contents will be extracted.
+    """
+    with zipfile.ZipFile(zip_filepath, "r") as zip_ref:
+        # Extract all files into the destination directory
         zip_ref.extractall(dest_path)
 
 
-def download_from_uci(name):
+def download_from_uci(name: str) -> None:
+    """Download and extract a dataset from the UCI repository.
 
-    print(f'Start processing dataset {name} from UCI.')
-    save_dir = f'{DATA_DIR}/{name}'
+    The dataset is downloaded only if it does not already exist on disk.
+
+    Args:
+        name: Name of the dataset to download. Must exist in
+            :data:`NAME_URL_DICT_UCI`.
+    """
+
+    print(f"Start processing dataset {name} from UCI.")
+    save_dir = f"{DATA_DIR}/{name}"
     if not os.path.exists(save_dir):
         os.makedirs(save_dir)
 
         url = NAME_URL_DICT_UCI[name]
-        request.urlretrieve(url, f'{save_dir}/{name}.zip')
-        print(f'Finish downloading dataset from {url}, data has been saved to {save_dir}.')
-        
-        unzip_file(f'{save_dir}/{name}.zip', save_dir)
-        print(f'Finish unzipping {name}.')
-    
-    else:
-        print('Aready downloaded.')
+        request.urlretrieve(url, f"{save_dir}/{name}.zip")
+        print(
+            f"Finish downloading dataset from {url}, data has been saved to {save_dir}."
+        )
 
-if __name__ == '__main__':
-    for name in NAME_URL_DICT_UCI.keys():
-        download_from_uci(name)
-    
+        unzip_file(f"{save_dir}/{name}.zip", save_dir)
+        print(f"Finish unzipping {name}.")
+
+    else:
+        print("Aready downloaded.")
+
+
+if __name__ == "__main__":
+    for dataset_name in NAME_URL_DICT_UCI.keys():
+        download_from_uci(dataset_name)
+

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,19 @@
 import argparse
 import importlib
+from typing import Callable
 
-def execute_function(method, mode):
+
+def execute_function(method: str, mode: str) -> Callable[[argparse.Namespace], None]:
+    """Resolve the main function for a given method and mode.
+
+    Args:
+        method: Name of the model or baseline to execute.
+        mode: Either ``'train'`` or ``'sample'`` depending on the task.
+
+    Returns:
+        The callable ``main`` function from the corresponding module.
+    """
+
     if method == 'vae':
         mode = 'train'
     mode = 'main' if mode == 'train' else 'sample'
@@ -11,7 +23,9 @@ def execute_function(method, mode):
     elif method == 'tabsyn':
         module_name = f"tabsyn.{mode}"
     elif method == 'tabddpm':
-        module_name = f"baselines.tabddpm.main_train" if mode == 'main' else f"baselines.tabddpm.main_sample"
+        module_name = (
+            f"baselines.tabddpm.main_train" if mode == 'main' else f"baselines.tabddpm.main_sample"
+        )
     else:
         module_name = f"baselines.{method}.{mode}"
 
@@ -26,7 +40,9 @@ def execute_function(method, mode):
         exit(1)
     return train_function
 
-def get_args():
+
+def get_args() -> argparse.Namespace:
+    """Parse and return command-line arguments for the pipeline."""
     parser = argparse.ArgumentParser(description='Pipeline')
 
     # General configs

--- a/utils_train.py
+++ b/utils_train.py
@@ -3,43 +3,87 @@ import os
 
 import src
 from torch.utils.data import Dataset
+from typing import Iterable, Tuple, Optional, Callable, Union, Any
 
 
 class TabularDataset(Dataset):
-    def __init__(self, X_num, X_cat):
+    """Simple dataset holding numerical and categorical features."""
+
+    def __init__(self, X_num: np.ndarray, X_cat: np.ndarray) -> None:
+        """Initialize the dataset.
+
+        Args:
+            X_num: Array of numerical features.
+            X_cat: Array of categorical features.
+        """
         self.X_num = X_num
         self.X_cat = X_cat
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Tuple[np.ndarray, np.ndarray]:
+        """Return a single sample.
+
+        Args:
+            index: Index of the desired sample.
+
+        Returns:
+            A tuple ``(this_num, this_cat)`` of numerical and categorical values.
+        """
         this_num = self.X_num[index]
         this_cat = self.X_cat[index]
-
         sample = (this_num, this_cat)
-
         return sample
 
-    def __len__(self):
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset."""
         return self.X_num.shape[0]
 
-def preprocess(dataset_path, task_type = 'binclass', inverse = False, cat_encoding = None, concat = True):
-    
-    T_dict = {}
+def preprocess(
+    dataset_path: str,
+    task_type: str = 'binclass',
+    inverse: bool = False,
+    cat_encoding: Optional[str] = None,
+    concat: bool = True,
+) -> Union[
+    Tuple[Tuple[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray], np.ndarray, int],
+    Tuple[Tuple[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray], np.ndarray, int, Callable[..., Any], Callable[..., Any]],
+    src.Dataset,
+]:
+    """Load and preprocess a dataset for training.
 
-    T_dict['normalization'] = "quantile"
-    T_dict['num_nan_policy'] = 'mean'
-    T_dict['cat_nan_policy'] =  None
-    T_dict['cat_min_frequency'] = None
-    T_dict['cat_encoding'] = cat_encoding
-    T_dict['y_policy'] = "default"
+    Depending on ``cat_encoding`` the function returns either the processed
+    arrays (possibly along with inverse transforms) or a :class:`src.Dataset`
+    instance.
+
+    Args:
+        dataset_path: Path to the dataset directory.
+        task_type: Task type, e.g. ``'binclass'`` or ``'regression'``.
+        inverse: Whether to return inverse transformation functions.
+        cat_encoding: Encoding method for categorical features. If ``None``,
+            arrays are returned. Otherwise, a dataset object is returned.
+        concat: Whether to concatenate the target column to feature arrays.
+
+    Returns:
+        Either tuples of arrays (with optional inverse transforms) or a
+        :class:`src.Dataset` depending on ``cat_encoding``.
+    """
+
+    T_dict = {
+        'normalization': "quantile",
+        'num_nan_policy': 'mean',
+        'cat_nan_policy': None,
+        'cat_min_frequency': None,
+        'cat_encoding': cat_encoding,
+        'y_policy': "default",
+    }
 
     T = src.Transformations(**T_dict)
 
     dataset = make_dataset(
-        data_path = dataset_path,
-        T = T,
-        task_type = task_type,
-        change_val = False,
-        concat = concat
+        data_path=dataset_path,
+        T=T,
+        task_type=task_type,
+        change_val=False,
+        concat=concat,
     )
 
     if cat_encoding is None:
@@ -48,39 +92,47 @@ def preprocess(dataset_path, task_type = 'binclass', inverse = False, cat_encodi
 
         X_train_num, X_test_num = X_num['train'], X_num['test']
         X_train_cat, X_test_cat = X_cat['train'], X_cat['test']
-        
+
         categories = src.get_categories(X_train_cat)
         d_numerical = X_train_num.shape[1]
 
         X_num = (X_train_num, X_test_num)
         X_cat = (X_train_cat, X_test_cat)
 
-
         if inverse:
             num_inverse = dataset.num_transform.inverse_transform
             cat_inverse = dataset.cat_transform.inverse_transform
-
             return X_num, X_cat, categories, d_numerical, num_inverse, cat_inverse
-        else:
-            return X_num, X_cat, categories, d_numerical
-    else:
-        return dataset
+        return X_num, X_cat, categories, d_numerical
+
+    return dataset
 
 
-def update_ema(target_params, source_params, rate=0.999):
-    """
-    Update target parameters to be closer to those of source parameters using
-    an exponential moving average.
-    :param target_params: the target parameter sequence.
-    :param source_params: the source parameter sequence.
-    :param rate: the EMA rate (closer to 1 means slower).
+def update_ema(
+    target_params: Iterable, source_params: Iterable, rate: float = 0.999
+) -> None:
+    """Update ``target_params`` toward ``source_params`` using EMA.
+
+    Args:
+        target_params: Iterable of parameters to be updated in-place.
+        source_params: Iterable of source parameters providing new values.
+        rate: Exponential moving average rate. Closer to 1 means slower update.
     """
     for target, source in zip(target_params, source_params):
         target.detach().mul_(rate).add_(source.detach(), alpha=1 - rate)
 
 
 
-def concat_y_to_X(X, y):
+def concat_y_to_X(X: Optional[np.ndarray], y: np.ndarray) -> np.ndarray:
+    """Concatenate target ``y`` as the first column of ``X``.
+
+    Args:
+        X: Feature matrix or ``None``.
+        y: Target values.
+
+    Returns:
+        The concatenated array. If ``X`` is ``None`` only ``y`` is returned.
+    """
     if X is None:
         return y.reshape(-1, 1)
     return np.concatenate([y.reshape(-1, 1), X], axis=1)
@@ -89,14 +141,26 @@ def concat_y_to_X(X, y):
 def make_dataset(
     data_path: str,
     T: src.Transformations,
-    task_type,
+    task_type: str,
     change_val: bool,
-    concat = True,
-):
+    concat: bool = True,
+) -> src.Dataset:
+    """Read raw numpy data and construct a :class:`src.Dataset` instance.
+
+    Args:
+        data_path: Path where ``*_train.npy`` files are stored.
+        T: Transformation pipeline to apply.
+        task_type: Either ``'binclass'``, ``'multiclass'`` or ``'regression'``.
+        change_val: Whether to modify validation split via :func:`src.change_val`.
+        concat: If ``True`` concatenate labels to the feature arrays.
+
+    Returns:
+        A transformed :class:`src.Dataset` ready for model consumption.
+    """
 
     # classification
     if task_type == 'binclass' or task_type == 'multiclass':
-        X_cat = {} if os.path.exists(os.path.join(data_path, 'X_cat_train.npy'))  else None
+        X_cat = {} if os.path.exists(os.path.join(data_path, 'X_cat_train.npy')) else None
         X_num = {} if os.path.exists(os.path.join(data_path, 'X_num_train.npy')) else None
         y = {} if os.path.exists(os.path.join(data_path, 'y_train.npy')) else None
 
@@ -107,7 +171,7 @@ def make_dataset(
             if X_cat is not None:
                 if concat:
                     X_cat_t = concat_y_to_X(X_cat_t, y_t)
-                X_cat[split] = X_cat_t  
+                X_cat[split] = X_cat_t
             if y is not None:
                 y[split] = y_t
     else:
@@ -136,19 +200,11 @@ def make_dataset(
         y,
         y_info={},
         task_type=src.TaskType(info['task_type']),
-        n_classes=info.get('n_classes')
+        n_classes=info.get('n_classes'),
     )
 
     if change_val:
         D = src.change_val(D)
 
-    # def categorical_to_idx(feature):
-    #     unique_categories = np.unique(feature)
-    #     idx_mapping = {category: index for index, category in enumerate(unique_categories)}
-    #     idx_feature = np.array([idx_mapping[category] for category in feature])
-    #     return idx_feature
-
-    # for split in ['train', 'val', 'test']:
-    # D.y[split] = categorical_to_idx(D.y[split].squeeze(1))
-
+    # The dataset is transformed in-place using the provided transformations
     return src.transform_dataset(D, T, None)


### PR DESCRIPTION
## Summary
- add detailed type hints and Google-style docstrings to dataset downloader, preprocessing utilities, EMA helpers and sampling step
- clarify helper functions with inline comments and annotations for easier comprehension

## Testing
- `python -m py_compile download_dataset.py process_dataset.py impute.py utils_train.py utils.py eval_impute.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688fc30c56108331a65f43db5cbaded5