### PR TITLE
refactor: address static analysis warnings

### DIFF
--- a/process_dataset.py
+++ b/process_dataset.py
@@ -66,11 +66,6 @@ def preprocess_news() -> None:
     data_save_path = 'data/news/news.csv'
     data_df.to_csv(f'{data_save_path}', index=False)
 
-    columns = np.array(data_df.columns.tolist())
-    num_columns = columns[list(range(45))]
-    cat_columns = ['data_channel', 'weekday']
-    target_columns = columns[[45]]
-
     info['num_col_idx'] = list(range(45))
     info['cat_col_idx'] = [46, 47]
     info['target_col_idx'] = [45]

--- a/tabsyn/diffusion_utils.py
+++ b/tabsyn/diffusion_utils.py
@@ -152,8 +152,7 @@ class VPLoss:
         y, augment_labels = augment_pipe(data) if augment_pipe is not None else (data, None)
         n = torch.randn_like(y) * sigma
         D_yn = denosie_fn(y + n, sigma, labels, augment_labels=augment_labels)
-        loss = weight * ((D_yn - y) ** 2)
-        return loss
+        return weight * ((D_yn - y) ** 2)
 
     def sigma(self, t: torch.Tensor) -> torch.Tensor:
         """Compute the noise level from a time value.
@@ -263,8 +262,7 @@ class VELoss:
             n = torch.randn_like(y) * sigma
             D_yn = denosie_fn(y + n, sigma, labels, augment_labels=augment_labels)
 
-        loss = weight * ((D_yn - y) ** 2)
-        return loss
+        return weight * ((D_yn - y) ** 2)
 
 #----------------------------------------------------------------------------
 # Improved loss function proposed in the paper "Elucidating the Design Space
@@ -320,7 +318,5 @@ class EDMLoss:
         D_yn = denoise_fn(y + n, sigma)
 
         target = y
-        loss = weight.unsqueeze(1) * ((D_yn - target) ** 2)
-
-        return loss
+        return weight.unsqueeze(1) * ((D_yn - target) ** 2)
 

--- a/tabsyn/latent_utils.py
+++ b/tabsyn/latent_utils.py
@@ -226,7 +226,5 @@ def process_invalid_id(
         ``syn_cat`` with all values clipped to the provided bounds.
     """
 
-    syn_cat = np.clip(syn_cat, min_cat, max_cat)
-
-    return syn_cat
+    return np.clip(syn_cat, min_cat, max_cat)
 

--- a/tabsyn/main.py
+++ b/tabsyn/main.py
@@ -38,7 +38,7 @@ def main(args: Namespace) -> None:
 
     in_dim = train_z.shape[1]
 
-    mean, std = train_z.mean(0), train_z.std(0)
+    mean = train_z.mean(0)
 
     # Normalize latent vectors to improve training stability.
     train_z = (train_z - mean) / 2

--- a/tabsyn/model.py
+++ b/tabsyn/model.py
@@ -56,8 +56,7 @@ class PositionalEmbedding(torch.nn.Module):
         freqs = freqs / (self.num_channels // 2 - (1 if self.endpoint else 0))
         freqs = (1 / self.max_positions) ** freqs
         x = x.ger(freqs.to(x.dtype))
-        x = torch.cat([x.cos(), x.sin()], dim=1)
-        return x
+        return torch.cat([x.cos(), x.sin()], dim=1)
 
 
 def reglu(x: Tensor) -> Tensor:
@@ -141,8 +140,7 @@ class FourierEmbedding(torch.nn.Module):
             Tensor containing concatenated ``cos`` and ``sin`` features.
         """
         x = x.ger((2 * np.pi * self.freqs).to(x.dtype))
-        x = torch.cat([x.cos(), x.sin()], dim=1)
-        return x
+        return torch.cat([x.cos(), x.sin()], dim=1)
 
 
 class MLPDiffusion(nn.Module):
@@ -251,8 +249,7 @@ class Precond(nn.Module):
         F_x = self.denoise_fn_F((x_in).to(dtype), c_noise.flatten())
 
         assert F_x.dtype == dtype
-        D_x = c_skip * x + c_out * F_x.to(torch.float32)
-        return D_x
+        return c_skip * x + c_out * F_x.to(torch.float32)
 
     def round_sigma(self, sigma: Tensor) -> Tensor:
         """Round ``sigma`` to the nearest supported value.

--- a/tabsyn/sample.py
+++ b/tabsyn/sample.py
@@ -28,9 +28,7 @@ def main(args: Namespace) -> None:
         None. Synthetic samples are written to ``args.save_path``.
     """
 
-    dataname = args.dataname
     device = args.device
-    steps = args.steps
     save_path = args.save_path
 
     train_z, _, _, ckpt_path, info, num_inverse, cat_inverse = get_input_generate(args)

--- a/tabsyn/vae/main.py
+++ b/tabsyn/vae/main.py
@@ -9,8 +9,6 @@ import os
 import time
 import warnings
 
-import numpy as np
-import torch
 import torch.nn as nn
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from torch.utils.data import DataLoader

--- a/tabsyn/vae/model.py
+++ b/tabsyn/vae/model.py
@@ -82,8 +82,7 @@ class MLP(nn.Module):
         """Forward pass through the MLP."""
         x = F.relu(self.fc1(x))
         x = self.dropout_layer(x)
-        x = self.fc2(x)
-        return x
+        return self.fc2(x)
 
 
 class MultiheadAttention(nn.Module):
@@ -227,7 +226,7 @@ class Transformer(nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         """Apply the Transformer layers."""
-        for layer_idx, layer in enumerate(self.layers):
+        for layer in self.layers:
             x_residual = self._start_residual(x, layer, 0)
             x_residual = layer["attention"](x_residual, x_residual)
 
@@ -263,9 +262,7 @@ class AE(nn.Module):
         """Forward pass through the autoencoder."""
 
         z = self.encoder(x, x)
-        h = self.decoder(z, z)
-
-        return h
+        return self.decoder(z, z)
 
 
 class VAE(nn.Module):
@@ -412,9 +409,7 @@ class Encoder_model(nn.Module):
     def forward(self, x_num: Tensor, x_cat: Tensor) -> Tensor:
         """Encode inputs to latent space."""
         x = self.Tokenizer(x_num, x_cat)
-        z = self.VAE_Encoder(x)
-
-        return z
+        return self.VAE_Encoder(x)
 
 
 class Decoder_model(nn.Module):

--- a/utils.py
+++ b/utils.py
@@ -31,7 +31,7 @@ def execute_function(method: str, mode: str) -> Callable[[argparse.Namespace], N
 
     try:
         train_module = importlib.import_module(module_name)
-        train_function = getattr(train_module, 'main')
+        train_function = train_module.main
     except ModuleNotFoundError:
         print(f"Module {module_name} not found.")
         exit(1)
@@ -162,6 +162,4 @@ def get_args() -> argparse.Namespace:
     parser.add_argument('--save_path', type=str, default=None, help='Path to save synthetic data.')
     parser.add_argument('--steps', type=int, default=50, help='NFEs.')
     
-    args = parser.parse_args()
-
-    return args
+    return parser.parse_args()

--- a/utils_train.py
+++ b/utils_train.py
@@ -30,8 +30,7 @@ class TabularDataset(Dataset):
         """
         this_num = self.X_num[index]
         this_cat = self.X_cat[index]
-        sample = (this_num, this_cat)
-        return sample
+        return this_num, this_cat
 
     def __len__(self) -> int:
         """Return the number of samples in the dataset."""


### PR DESCRIPTION
## Summary
- remove redundant imports and shadowed variables in VAE utilities
- streamline returns and eliminate unnecessary assignments in training helpers and models
- simplify argument parsing and dataset processing

## Testing
- `ruff check *.py --select=E722,F821,F811,F841,RET,B`
- `ruff check tabsyn --select=E722,F821,F811,F841,RET,B`
- `ruff check tabsyn/vae --select=E722,F821,F811,F841,RET,B`


------
https://chatgpt.com/codex/tasks/task_b_688fc92f41308331ad1a833933a39be2